### PR TITLE
Change keepProjectilesTicked to keepEnderPearlsTicked

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Places the mined block in the player inventory when sneaking.
 * Required options: `true`, `false`  
 * Categories: `SURVIVAL`, `FEATURE`, `EXPERIMENTAL`
 
-### keepProjectilesTicked
-Projectiles are ticked the whole time - Projectile loading chunks.  
+### keepEnderPearlsTicked
+Ender Pearls are ticked the whole time - Ender Pearl loading chunks.  
 * Type: `boolean`  
 * Default value: `false`  
 * Required options: `true`, `false`  

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ org.gradle.jvmargs=-Xmx1G
 	carpet_core_version=1.4.18+v201121
 
 # Mod Properties
-	mod_version = 1.0.6+v201122
+	mod_version = 1.0.7+201221
 	maven_group = carpet-addons
 	archives_base_name = carpet-addons
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ org.gradle.jvmargs=-Xmx1G
 	carpet_core_version=1.4.18+v201121
 
 # Mod Properties
-	mod_version = 1.0.7+201221
+	mod_version = 1.0.7+v201221
 	maven_group = carpet-addons
 	archives_base_name = carpet-addons
 

--- a/src/main/java/carpetaddons/CarpetAddonsSettings.java
+++ b/src/main/java/carpetaddons/CarpetAddonsSettings.java
@@ -45,7 +45,7 @@ public class CarpetAddonsSettings
             desc = "Projectiles are ticked the whole time - Projectile loading chunks",
             category = {FEATURE, EXPERIMENTAL, "carpetaddons"}
     )
-    public static boolean keepProjectilesTicked = false;
+    public static boolean keepEnderPearlsTicked = false;
 
 
     @Rule(

--- a/src/main/java/carpetaddons/mixins/ServerChunkManagerMixin.java
+++ b/src/main/java/carpetaddons/mixins/ServerChunkManagerMixin.java
@@ -2,7 +2,7 @@ package carpetaddons.mixins;
 
 import carpetaddons.CarpetAddonsSettings;
 import net.minecraft.entity.Entity;
-import net.minecraft.entity.projectile.ProjectileEntity;
+import net.minecraft.entity.projectile.thrown.EnderPearlEntity;
 import net.minecraft.server.world.ServerChunkManager;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -13,7 +13,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 public class ServerChunkManagerMixin {
     @Inject(method = "shouldTickEntity", at = @At(value = "HEAD"), cancellable =  true)
     private void onShouldTickEntity(Entity entity, CallbackInfoReturnable<Boolean> cir){
-        if(CarpetAddonsSettings.keepProjectilesTicked && entity instanceof ProjectileEntity)
+        if(CarpetAddonsSettings.keepEnderPearlsTicked && entity instanceof EnderPearlEntity)
             cir.setReturnValue(true);
     }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "id": "carpet-addons",
-  "version": "1.0.4",
+  "version": "1.0.7",
 
   "name": "Carpet Addons",
   "description": "More useful features for carpet",


### PR DESCRIPTION
Changes `instanceof ProjectileEntity` to `instanceof EnderPearlEntity` in order to prevent other projectiles (like Ghast fireballs :eyes:) from loading chunks.