### PR TITLE
Changed fabric.mod.json

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -32,5 +32,8 @@
   },
   "suggests": {
     "flamingo": "*"
+  },
+  "custom": {
+    "modmenu:parent": "carpet"
   }
 }


### PR DESCRIPTION
Changed fabric.mod.json to make it so that carpet addons displays as a sub-part of carpet in modmenu, as Carpet TIS Additions has already done.