### PR TITLE
Fixes compatibility with aleph-carpet

### DIFF
--- a/src/main/java/carpetaddons/mixins/AbstractFireBlockMixin.java
+++ b/src/main/java/carpetaddons/mixins/AbstractFireBlockMixin.java
@@ -13,7 +13,7 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 @Mixin(AbstractFireBlock.class)
 public class AbstractFireBlockMixin {
 
-    @Redirect(method = "method_30032", at = @At(value = "INVOKE", target = "Lnet/minecraft/block/BlockState;canPlaceAt(Lnet/minecraft/world/WorldView;Lnet/minecraft/util/math/BlockPos;)Z"))
+    @Redirect(method = "method_30032", require = 0, at = @At(value = "INVOKE", target = "Lnet/minecraft/block/BlockState;canPlaceAt(Lnet/minecraft/world/WorldView;Lnet/minecraft/util/math/BlockPos;)Z"))
     private static boolean canPlaceAt(BlockState blockState, WorldView world, BlockPos pos){
         if(CarpetAddonsSettings.oldFlintAndSteelBehavior)
             return true;


### PR DESCRIPTION
When using aleph carpet, the (identical) aleph carpet rule is used. Without aleph carpet, this mod's rule works as well as it did before. Fixes #10.